### PR TITLE
Deprecate the knp_menu.matcher.configure callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Removed support for Symfony 2.3 components (which are unmaintained already), to get the RequestStack support.
 
+### Deprecated
+
+* Deprecated the "knp_menu.matcher.configure" callback in favor of extending the "knp_menu.matcher" service.
+
 ## [1.0.1] - 2017-08-22
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.1-dev"
         }
     }
 }

--- a/src/MenuServiceProvider.php
+++ b/src/MenuServiceProvider.php
@@ -38,6 +38,7 @@ class MenuServiceProvider implements ServiceProviderInterface
             }
 
             if (isset($app['knp_menu.matcher.configure'])) {
+                @trigger_error('Defining a "knp_menu.matcher.configure" to configure the matcher is deprecated since 1.1 and won\'t be supported in 2.0. Extend the "knp_menu.matcher" service instead.', E_USER_DEPRECATED);
                 $app['knp_menu.matcher.configure']($matcher);
             }
 


### PR DESCRIPTION
Pimple has a native way of extending service definitions, which should be used instead.