### PR TITLE
Register the route voter by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Register the RouteVoter by default
+
+### Removed
+
+* Removed support for Symfony 2.3 components (which are unmaintained already), to get the RequestStack support.
+
 ## [1.0.1] - 2017-08-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ use Knp\Menu\Silex\MenuServiceProvider;
 $app->register(new MenuServiceProvider());
 ```
 
-
 #### Parameters
 
 * **knp_menu.menus** (optional): an array of ``alias => id`` pair for the
@@ -42,6 +41,8 @@ $app->register(new MenuServiceProvider());
 * **knp_menu.renderer.list**: The ListRenderer
 * **knp_menu.renderer.twig**: The TwigRenderer (only when the Twig integration is available)
 * **knp_menu.menu_manipulator**: The MenuManipulator
+* **knp_menu.matcher**: The KnpMenu Matcher
+* **knp_menu.voter.route**: The RouteVoter registered in the matcher. Unset it from the container to unregister it.
 
 > **WARNING**
 > The Twig integration is available only when the MenuServiceProvider is registered

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,9 @@
     ],
     "require": {
         "php":  ">=5.3.0",
-        "knplabs/knp-menu": "^2.2",
-        "silex/silex": "^1.3"
+        "knplabs/knp-menu": "^2.3",
+        "silex/silex": "^1.3",
+        "symfony/http-kernel": "^2.4 || ^3.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^3.3",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php":  ">=5.3.0",
-        "knplabs/knp-menu": "^2.3",
+        "knplabs/knp-menu": "^2.3@dev",
         "silex/silex": "^1.3",
         "symfony/http-kernel": "^2.4 || ^3.0"
     },

--- a/src/MenuServiceProvider.php
+++ b/src/MenuServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Knp\Menu\Silex;
 
 use Knp\Menu\Integration\Symfony\RoutingExtension;
+use Knp\Menu\Matcher\Voter\RouteVoter;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Knp\Menu\Matcher\Matcher;
@@ -32,11 +33,19 @@ class MenuServiceProvider implements ServiceProviderInterface
         $app['knp_menu.matcher'] = $app->share(function() use ($app) {
             $matcher = new Matcher();
 
+            if (isset($app['knp_menu.voter.router'])) {
+                $matcher->addVoter($app['knp_menu.voter.router']);
+            }
+
             if (isset($app['knp_menu.matcher.configure'])) {
                 $app['knp_menu.matcher.configure']($matcher);
             }
 
             return $matcher;
+        });
+
+        $app['knp_menu.voter.router'] = $app->share(function() use ($app) {
+            return new RouteVoter($app['request_stack']);
         });
 
         $app['knp_menu.renderer.list'] = $app->share(function() use ($app) {

--- a/tests/MenuServiceProviderTest.php
+++ b/tests/MenuServiceProviderTest.php
@@ -86,17 +86,6 @@ class KnpMenuServiceProviderTest extends TestCase
             return $root;
         };
 
-        $app['test.voter'] = $app->share(function (Application $app) {
-            $voter = new RouteVoter();
-            $voter->setRequest($app['request']);
-
-            return $voter;
-        });
-
-        $app['knp_menu.matcher.configure'] = $app->protect(function (Matcher $matcher) use ($app) {
-            $matcher->addVoter($app['test.voter']);
-        });
-
         $app->get('/twig', function (Application $app) {
             return $app['twig']->render('main', array('renderer' => 'twig'));
         })->bind('homepage');


### PR DESCRIPTION
This PR depends on https://github.com/KnpLabs/KnpMenu/pull/222 to be released, as I want to inject the RequestStack in it rather than the Request (and so I bumped the min version, even though it is not released yet).

This PR is meant to replace https://github.com/KnpLabs/KnpMenu/pull/193. It does not make the RouteVoter opt-in (it allows to opt-out though). As people have to migrate to a new dependency, I consider it OK that they need to update their code if they don't want this voter.